### PR TITLE
Using string comparison in order to remove maven dependency. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>javadoc</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>2.8</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/HardcodedScriptChecker.java
+++ b/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/HardcodedScriptChecker.java
@@ -28,7 +28,7 @@ public class HardcodedScriptChecker extends AbstractCheck {
     public boolean executeCheck(Item item) {
         LOG.log(Level.FINE, "executeCheck " + item);
         boolean found = false;
-        if (item instanceof hudson.maven.MavenModuleSet) {
+        if (item.getClass().getName().endsWith("hudson.maven.MavenModuleSet")) {
             found = false;
         } else {
             if (item instanceof Project) {

--- a/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/MavenJobTypeChecker.java
+++ b/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/MavenJobTypeChecker.java
@@ -18,6 +18,6 @@ public class MavenJobTypeChecker extends AbstractCheck{
     }
 
     public boolean executeCheck(Item item) {
-        return item instanceof hudson.maven.MavenModuleSet;
+        return item.getClass().getName().endsWith("hudson.maven.MavenModuleSet");
     }
 }


### PR DESCRIPTION
- https://issues.jenkins-ci.org/browse/JENKINS-29544
- Removed optional plugin.
- Using string comparison rather than class comparison
