### PR TITLE
Timeout check

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ List available Checks
 * Multibranch Job Type check
 * Hardcoded Script check
 * Gradle Wrapper check
+* Build timeout check
 * Slave description check
 * Slave label check
 * Slave version check

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ List available Checks
 * Multibranch Job Type check
 * Hardcoded Script check
 * Gradle Wrapper check
+* Slave description check
+* Slave label check
+* Slave version check
+* Windows slave launch check
 
 
 Development

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>build-timeout</artifactId>
+      <version>1.15</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- JENKINS-29427 -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkins/ci/plugins/jenkinslint/JenkinsLintAction.java
+++ b/src/main/java/org/jenkins/ci/plugins/jenkinslint/JenkinsLintAction.java
@@ -23,6 +23,7 @@ import org.jenkins.ci.plugins.jenkinslint.check.PollingSCMTriggerChecker;
 import org.jenkins.ci.plugins.jenkinslint.check.SlaveDescriptionChecker;
 import org.jenkins.ci.plugins.jenkinslint.check.SlaveLabelChecker;
 import org.jenkins.ci.plugins.jenkinslint.check.SlaveVersionChecker;
+import org.jenkins.ci.plugins.jenkinslint.check.TimeoutChecker;
 import org.jenkins.ci.plugins.jenkinslint.check.WindowsSlaveLaunchChecker;
 import org.jenkins.ci.plugins.jenkinslint.model.InterfaceCheck;
 import org.jenkins.ci.plugins.jenkinslint.model.InterfaceSlaveCheck;
@@ -67,6 +68,7 @@ public final class JenkinsLintAction implements RootAction {
         checkList.add(new MultibranchJobTypeChecker());
         checkList.add(new HardcodedScriptChecker());
         checkList.add(new GradleWrapperChecker());
+        checkList.add(new TimeoutChecker());
 
         slaveCheckList.add(new SlaveDescriptionChecker());
         slaveCheckList.add(new SlaveVersionChecker());

--- a/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/TimeoutChecker.java
+++ b/src/main/java/org/jenkins/ci/plugins/jenkinslint/check/TimeoutChecker.java
@@ -1,0 +1,62 @@
+package org.jenkins.ci.plugins.jenkinslint.check;
+
+import hudson.matrix.MatrixProject;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Project;
+import hudson.tasks.BuildWrapper;
+import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
+import org.jenkins.ci.plugins.jenkinslint.model.AbstractCheck;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * @author Victor Martinez
+ */
+public class TimeoutChecker extends AbstractCheck {
+
+    public TimeoutChecker() {
+        super();
+        this.setDescription("There are some builds which might hang forever and cause inaction in the build queue and slaves. " +
+                "It's recommended to control those time based on the <a href=https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin>>build timeout plugin</a>.");
+        this.setSeverity("Medium");
+    }
+
+    public boolean executeCheck(Item item) {
+        boolean notfound = true;
+        if (Jenkins.getInstance().pluginManager.getPlugin("build-timeout") != null) {
+            if (item.getClass().getName().endsWith("hudson.maven.MavenModuleSet")) {
+                try {
+                    Method method = item.getClass().getMethod("getBuildWrappersList");
+                    DescribableList<BuildWrapper,Descriptor<BuildWrapper>> buildWrapperList = ((DescribableList<BuildWrapper,Descriptor<BuildWrapper>>) method.invoke(item));
+                    notfound = !isTimeout(buildWrapperList);
+                } catch (Exception e) {
+                    LOG.log(Level.WARNING, "Exception " + e.getMessage(), e.getCause());
+                    notfound = false;
+                }
+            }
+            if (item instanceof Project) {
+                notfound = !isTimeout(((Project) item).getBuildWrappersList());
+            }
+            if (item instanceof MatrixProject) {
+                notfound = !isTimeout(((MatrixProject) item).getBuildWrappersList());
+            }
+        }
+        return notfound;
+    }
+
+    private boolean isTimeout(List<BuildWrapper> builders) {
+        boolean status = false;
+        if (builders != null && builders.size() > 0 ) {
+            for (BuildWrapper builder : builders) {
+                if (builder.getClass().getName().endsWith("BuildTimeoutWrapper")) {
+                    status = true;
+                }
+            }
+        }
+        return status;
+    }
+}

--- a/src/test/java/org/jenkins/ci/plugins/jenkinslint/check/TimeoutCheckerTestCase.java
+++ b/src/test/java/org/jenkins/ci/plugins/jenkinslint/check/TimeoutCheckerTestCase.java
@@ -1,0 +1,125 @@
+package org.jenkins.ci.plugins.jenkinslint.check;
+
+import hudson.matrix.MatrixProject;
+import hudson.maven.MavenModuleSet;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.build_timeout.BuildTimeoutWrapper;
+import hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy;
+import hudson.plugins.build_timeout.impl.DeadlineTimeOutStrategy;
+import hudson.plugins.build_timeout.impl.ElasticTimeOutStrategy;
+import hudson.plugins.build_timeout.impl.LikelyStuckTimeOutStrategy;
+import hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TimeoutChecker Test Case.
+ *
+ * @author Victor Martinez
+ */
+public class TimeoutCheckerTestCase {
+    private TimeoutChecker checker = new TimeoutChecker();
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+    @Test public void testDefaultJob() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        assertTrue(checker.executeCheck(project));
+    }
+    @Test public void testMavenJobName() throws Exception {
+        MavenModuleSet project = j.createMavenProject();
+        assertTrue(checker.executeCheck(project));
+    }
+    //@Issue("JENKINS-29444")
+    @Test public void testMatrixProject() throws Exception {
+        MatrixProject project = j.createMatrixProject();
+        assertTrue(checker.executeCheck(project));
+    }
+    @Test public void testMatrixProjectWithTimeout() throws Exception {
+        MatrixProject project = j.createMatrixProject("NoActivityTimeOut");
+        project.getBuildWrappersList().add(createNoActivityTimeOut());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createMatrixProject("AbsoluteTimeOutStrategy");
+        project.getBuildWrappersList().add(createAbsoluteTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createMatrixProject("DeadlineTimeOutStrategy");
+        project.getBuildWrappersList().add(createDeadlineTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createMatrixProject("ElasticTimeOutStrategy");
+        project.getBuildWrappersList().add(createElasticTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createMatrixProject("LikelyStuckTimeOutStrategy");
+        project.getBuildWrappersList().add(createLikelyStuckTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+    }
+    @Test public void testJobWithTimeout() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("NoActivityTimeOut");
+        project.getBuildWrappersList().add(createNoActivityTimeOut());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createFreeStyleProject("AbsoluteTimeOutStrategy");
+        project.getBuildWrappersList().add(createAbsoluteTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createFreeStyleProject("DeadlineTimeOutStrategy");
+        project.getBuildWrappersList().add(createDeadlineTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createFreeStyleProject("ElasticTimeOutStrategy");
+        project.getBuildWrappersList().add(createElasticTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+        project.delete();
+        project = j.createFreeStyleProject("LikelyStuckTimeOutStrategy");
+        project.getBuildWrappersList().add(createLikelyStuckTimeOutStrategy());
+        assertFalse(checker.executeCheck(project));
+    }
+    @Test public void testControlComment() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        assertFalse(checker.isIgnored(project.getDescription()));
+        project.setDescription("#lint:ignore:" + checker.getClass().getSimpleName());
+        assertTrue(checker.isIgnored(project.getDescription()));
+    }
+    //@Issue("JENKINS-29427")
+    @Test public void testAnotherBuilders() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("MsBuildBuilder");
+        project.getBuildersList().add(new hudson.plugins.msbuild.MsBuildBuilder("", "", "", true, true, true));
+        assertTrue(checker.executeCheck(project));
+        project.delete();
+        project = j.createFreeStyleProject("Ant");
+        project.getBuildersList().add(new hudson.tasks.Ant("","","","",""));
+        assertTrue(checker.executeCheck(project));
+        project.delete();
+    }
+
+    private BuildTimeoutWrapper createNoActivityTimeOut() {
+        NoActivityTimeOutStrategy strategy = new NoActivityTimeOutStrategy("120");
+        return new BuildTimeoutWrapper(strategy, null, null);
+    }
+
+    private BuildTimeoutWrapper createAbsoluteTimeOutStrategy() {
+        AbsoluteTimeOutStrategy strategy = new AbsoluteTimeOutStrategy("120");
+        return new BuildTimeoutWrapper(strategy, null, null);
+    }
+
+    private BuildTimeoutWrapper createDeadlineTimeOutStrategy() {
+        DeadlineTimeOutStrategy strategy = new DeadlineTimeOutStrategy("120", 120);
+        return new BuildTimeoutWrapper(strategy, null, null);
+    }
+
+    private BuildTimeoutWrapper createElasticTimeOutStrategy() {
+        ElasticTimeOutStrategy strategy = new ElasticTimeOutStrategy("90","60","5");
+        return new BuildTimeoutWrapper(strategy, null, null);
+    }
+
+    private BuildTimeoutWrapper createLikelyStuckTimeOutStrategy() {
+        LikelyStuckTimeOutStrategy strategy = new LikelyStuckTimeOutStrategy();
+        return new BuildTimeoutWrapper(strategy, null, null);
+    }
+}


### PR DESCRIPTION
When creating jobs it is worth to add timeout plugin as part of it then it might reduce the inaction issues in the build queue when those jobs are hang.
- https://issues.jenkins-ci.org/browse/JENKINS-30725
